### PR TITLE
Changed castbar color for non enemies

### DIFF
--- a/modules/cast.lua
+++ b/modules/cast.lua
@@ -454,7 +454,7 @@ function Cast:UpdateCast(frame, unit, channelled, spell, rank, displayName, icon
 		cast:SetScript("OnUpdate", castOnUpdate)
 	end
 	
-	if( notInterruptible ) then
+	if( notInterruptible and UnitIsEnemy("player", unit) ) then
 		setBarColor(cast, ShadowUF.db.profile.castColors.uninterruptible.r, ShadowUF.db.profile.castColors.uninterruptible.g, ShadowUF.db.profile.castColors.uninterruptible.b)
 	elseif( cast.isChannelled ) then
 		setBarColor(cast, ShadowUF.db.profile.castColors.channel.r, ShadowUF.db.profile.castColors.channel.g, ShadowUF.db.profile.castColors.channel.b)


### PR DESCRIPTION
Changed castcolor of non enemy units from "uninteruptible color" to "cast color". This way the player cast bar pops out more visually, because of the default cast bar colors. It also makes the naming in the UI more consistent, the uninterruptible color will only be used for non interruptible casts.
